### PR TITLE
:bug: 修复GroupMessageCreateEvent群聊消息中发送者role传递空值或未传递导致Permission检测返回错误结果

### DIFF
--- a/src/nonebot_plugin_uninfo/adapters/qq/main.py
+++ b/src/nonebot_plugin_uninfo/adapters/qq/main.py
@@ -27,6 +27,12 @@ ROLES = {
     "1": ("MEMBER", 1, "成员"),
 }
 
+GROUP_ROLES = {
+    "owner": ("OWNER", 640, "群主"),
+    "admin": ("ADMINISTRATOR", 10, "管理员"),
+    "member": ("MEMBER", 1, "成员"),
+}
+
 
 CHANNEL_TYPE = {
     -1: SceneType.PRIVATE,
@@ -89,8 +95,9 @@ class InfoFetcher(BaseInfoFetcher):
 
     def extract_member(self, data, user: User | None):
         if "group_id" in data:
+            roles = [Role(*GROUP_ROLES[data["role"]])] if data.get("role") in GROUP_ROLES else []
             if user:
-                return Member(user, nick=data["nickname"])
+                return Member(user, nick=data["nickname"], roles=roles)
             return Member(
                 User(
                     id=data["user_id"],
@@ -98,6 +105,7 @@ class InfoFetcher(BaseInfoFetcher):
                     avatar=data.get("avatar"),
                 ),
                 nick=data["nickname"],
+                roles=roles,
             )
         if "guild_id" in data:
             if user:
@@ -298,6 +306,7 @@ async def _(bot: Bot, event: GroupMessageCreateEvent):
         "user_id": event.author.member_openid,
         "name": event.author.username,
         "nickname": "",
+        "role": getattr(event.author, "member_role", None),
         "avatar": f"https://q.qlogo.cn/qqapp/{bot.bot_info.id}/{event.author.member_openid}/640",
         "group_id": event.group_openid,
     }


### PR DESCRIPTION
### 概述

QQ 官方机器人适配器中，`nonebot_plugin_uninfo.permission` 里针对公开群聊的基于角色的权限检查全部失效。具体表现为：

- 群主在群里调用设置了 `OWNER()` 或 `ADMIN()` 权限检查的命令，Permission 检查不通过，命令无法触发；
- `MEMBER()` 反而对群主/管理员返回 `True`；
- `ROLE_IN()` / `ROLE_NOT_IN()` / `ROLE_LEVEL()` 同样无法按角色正确判断。

### 根因

`GroupMessageCreateEvent` 的 session 数据中未传递发送者的 `member_role` 字段（`GroupAtMessageCreateEvent` 继承自该类，同样受影响）：

```python
# 修复前
return {
    "user_id": event.author.member_openid,
    "name": event.author.username,
    "nickname": "",
    "avatar": ...,
    "group_id": event.group_openid,
}
```

导致 `InfoFetcher.extract_member()` 构造出的 `Member.roles` 恒为空列表 `[]`，而 `permission` 中的角色检查（`OWNER() = ROLE_IN("OWNER")`、`ADMIN() = ROLE_IN("ADMINISTRATOR", "OWNER")`、`MEMBER() = ROLE_NOT_IN(...)`）依赖 `sess.member.roles`，因此全部返回错误结果。

### 修复

1. `GroupMessageCreateEvent` 的 supply 中补充传递 `"role": getattr(event.author, "member_role", None)`，用 `getattr` 兜底旧版本适配器无该字段的情况；
2. 新增 `GROUP_ROLES` 映射：`owner/admin/member` → `OWNER(640) / ADMINISTRATOR(10) / MEMBER(1)`，与频道场景已有的 `ROLES` 等级体系保持一致；
3. `extract_member()` 按 `data["role"]` 构建 `Member.roles`，role 缺失或未知时保持空列表，不影响其他事件类型。

---

我已在纯净（nb create创建的）NoneBot中完成测试：直接安装插件时，出现相关问题；在修改插件代码后，问题得到解决。请审阅我的代码，确保我的代码没有做出破坏性更改。